### PR TITLE
Remove obsolete AZUREJOBS_EXTENSION_VERSION App Setting

### DIFF
--- a/Lesson3/arm-template.json
+++ b/Lesson3/arm-template.json
@@ -92,7 +92,6 @@
           "properties": {
             "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageName')), '2015-05-01-preview').key1,';')]",
             "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageName')), '2015-05-01-preview').key1,';')]",
-            "AZUREJOBS_EXTENSION_VERSION": "beta",
             "FUNCTIONS_EXTENSION_VERSION": "latest",
             "AzureIoTHubConnectionString": "[concat('HostName=', reference(variables('iotHubResourceId'), variables('iotHubVersion')).hostName, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]",
             "AzureIoTHubEventHubConnectionString": "[concat('Endpoint=', reference(variables('iotHubResourceId'), variables('iotHubVersion')).eventHubEndpoints.events.endpoint, ';SharedAccessKeyName=', variables('iotHubKeyName'), ';SharedAccessKey=', listkeys(variables('iotHubKeyResource'), variables('iotHubVersion')).primaryKey)]",


### PR DESCRIPTION
This setting is no longer needed and should be removed. It could cause issues going forward.